### PR TITLE
[generation] use private greedy/sampling methods

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import setuptools
 
 
 _deps = [
-    "transformers>=4.39.0",
+    "transformers>=4.39.0,<4.41.0",
     "torch",
     "sentencepiece",
     "descript-audio-codec",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import setuptools
 
 
 _deps = [
-    "transformers>=4.34.0",
+    "transformers>=4.39.0",
     "torch",
     "sentencepiece",
     "descript-audio-codec",


### PR DESCRIPTION
The PR https://github.com/huggingface/transformers/pull/29437 sets public decoding methods (`greedy_search`, `sampling`) to private methods (`_greedy_search`, `_sampling`). Furthermore, the generation logic was streamlined in https://github.com/huggingface/transformers/pull/29956, changes for which are also implemented in this PR.

The change from public -> private generation methods was part of the v4.39 PyPi release. Hence. we bump the min version in the requirements accordingly.

cc @gante