### PR TITLE
Add wer normalizer

### DIFF
--- a/training/arguments.py
+++ b/training/arguments.py
@@ -288,6 +288,14 @@ class DataTrainingArguments:
         default=2,
         metadata={"help": ("Pad to multiple of for tokenizers.")},
     )
+    use_english_normalizer: bool = field(
+        default=True,
+        metadata={
+            "help": (
+                "Whether or not to use an English normalizer for WER evaluation. If `False`, use basic normalizer (BasicTextNormalizer)."
+            )
+        },
+    )
 
 
 @dataclass

--- a/training/data.py
+++ b/training/data.py
@@ -31,7 +31,7 @@ class DataCollatorEncodecWithPadding:
         audios = [feature[self.audio_column_name]["array"] for feature in features]
         len_audio = [len(audio) for audio in audios]
 
-        # since resampling has already been performed in the 'load_multiple_datasets' function, 
+        # since resampling has already been performed in the 'load_multiple_datasets' function,
         # a fixed sampling_rate(44100hz) is passed to the feature_extractor.
         sampling_rate = self.feature_extractor.sampling_rate
         batch = self.feature_extractor(


### PR DESCRIPTION
WER evaluation measure only used `.lower` as a normalizer before computing WER. We now can use Whisper normalizer to compute it!

This addition has been tested on 2 A100 GPUs


cc @sanchit-gandhi, does it make sense to use the spelling normalizer from Whisper v3 as default ?