### PR TITLE
[training] apply `save_total_limit` to push

### DIFF
--- a/training/utils.py
+++ b/training/utils.py
@@ -3,7 +3,7 @@ import re
 import shutil
 from pathlib import Path
 from dataclasses import field
-from typing import Dict, List
+from typing import Dict, List, Union
 
 import torch
 from wandb import Audio
@@ -44,7 +44,7 @@ def sorted_checkpoints(output_dir=None, checkpoint_prefix="checkpoint") -> List[
     return checkpoints_sorted
 
 
-def rotate_checkpoints(save_total_limit=None, output_dir=None, checkpoint_prefix="checkpoint", logger=None) -> None:
+def rotate_checkpoints(save_total_limit=None, output_dir=None, checkpoint_prefix="checkpoint", logger=None) -> Union[List, None]:
     """Helper function to delete old checkpoints."""
     if save_total_limit is None or save_total_limit <= 0:
         return
@@ -58,6 +58,8 @@ def rotate_checkpoints(save_total_limit=None, output_dir=None, checkpoint_prefix
     for checkpoint in checkpoints_to_be_deleted:
         logger.info(f"Deleting older checkpoint [{checkpoint}] due to args.save_total_limit")
         shutil.rmtree(checkpoint, ignore_errors=True)
+    checkpoints_to_be_deleted = [f"*{Path(checkpoint).absolute().name}*"  for checkpoint in checkpoints_to_be_deleted]
+    return checkpoints_to_be_deleted
 
 
 def log_metric(


### PR DESCRIPTION
Currently, the argument `save_total_limit` can be used to control the number of locally saved checkpoints, but not those pushed to the Hub. This PR ensures `save_total_limit` is applied to both (in-line with the HF Trainer). It was tested with the following training config:

<details>

<summary> librispeech_tts_r_300M_dummy.json </summary>

```json
{
    "model_name_or_path": "./parler-tts-untrained-600M/parler-tts-untrained-600M/",
    "save_to_disk":  "./tmp_dataset_audio/",
    "temporary_save_to_disk": "./audio_code_tmp/",


    "feature_extractor_name":"ylacombe/dac_44khZ_8kbps",
    "description_tokenizer_name":"google/flan-t5-base",
    "prompt_tokenizer_name":"google/flan-t5-base",

    "report_to": ["wandb"],
    "overwrite_output_dir": true,
    "output_dir": "./parler-tts-save-total-limit",

    "train_dataset_name": "blabble-io/libritts_r",
    "train_metadata_dataset_name": "parler-tts/libritts_r_tags_tagged_10k_generated",
    "train_dataset_config_name": "clean",
    "train_split_name": "test.clean",

    "eval_dataset_name": "blabble-io/libritts_r",
    "eval_metadata_dataset_name": "parler-tts/libritts_r_tags_tagged_10k_generated",
    "eval_dataset_config_name": "clean",
    "eval_split_name": "test.clean",

    "target_audio_column_name": "audio", 
    "description_column_name": "text_description",
    "prompt_column_name": "text",

    "max_eval_samples": 48,
    "max_train_samples": 96,
    
    "max_duration_in_seconds": 20,
    "min_duration_in_seconds": 2.0,

    "add_audio_samples_to_wandb": true,
    "id_column_name": "id",

    "preprocessing_num_workers": 8,

    "do_train": true,
    "max_steps": 50,
    "gradient_accumulation_steps": 1,
    "gradient_checkpointing": false,
    "per_device_train_batch_size": 4,
    "learning_rate": 1e-3,
    "adam_beta1": 0.9,
    "adam_beta2": 0.99,
    "weight_decay": 0.01,

    "lr_scheduler_type": "cosine",
    "warmup_steps":  40,


    "logging_steps": 2,
    "freeze_text_encoder": true,


    "do_eval": false,
    "predict_with_generate": true,
    "include_inputs_for_metrics": true,
    "evaluation_strategy": "steps",
    "eval_steps": 50,
    "save_steps": 20,
    "push_to_hub": true,
    "save_total_limit": 1,

    "per_device_eval_batch_size": 12,

    "audio_encoder_per_device_batch_size":24,
    "dtype": "bfloat16",
    "seed": 456,

    "dataloader_num_workers":8
}
```

</details>

Which gives a repo where the checkpoints are rotated upon each save step, e.g. [sanchit-gandhi/parler-tts-save-total-limit](https://huggingface.co/sanchit-gandhi/parler-tts-save-total-limit/commit/a104b46caf7b7b055963f89b9a9a8bc4e8df6477)

The PR also saves the model config and generation config, such that a model can be loaded directly from a saved state.