### PR TITLE
Add possibility to have the audio output length

### DIFF
--- a/parler_tts/modeling_parler_tts.py
+++ b/parler_tts/modeling_parler_tts.py
@@ -3511,6 +3511,7 @@ class ParlerTTSForConditionalGeneration(PreTrainedModel):
                 output_ids,
                 audio_scales=audio_scales,
             ).audio_values.squeeze(1)
+            output_lengths = [audio.shape[0] for audio in output_values]
         else:
             output_values = []
             for sample_id in range(batch_size):
@@ -3522,13 +3523,14 @@ class ParlerTTSForConditionalGeneration(PreTrainedModel):
                     output_values.append(sample.transpose(0, 2))
                 else:
                     output_values.append(torch.zeros((1, 1, 1)).to(self.device))
-            # TODO: we should keep track of output length as well. Not really straightforward tbh
+            output_lengths = [audio.shape[0] for audio in output_values]
             output_values = (
                 torch.nn.utils.rnn.pad_sequence(output_values, batch_first=True, padding_value=0)
                 .squeeze(-1)
                 .squeeze(-1)
             )
         if generation_config.return_dict_in_generate:
+            outputs["audios_length"] = output_lengths
             outputs.sequences = output_values
             return outputs
         else:


### PR DESCRIPTION
Following an internal discussion, I've realized it was not possible to get the audio output length, which is especially useful when batching.

Here, I've decided to be backwards compatible: to get these audio lengths, one needs to add `return_dict_in_generate=True`:

```py
from parler_tts import ParlerTTSForConditionalGeneration
from transformers import AutoTokenizer, AutoFeatureExtractor, set_seed
import scipy


repo_id = "parler-tts/parler_tts_mini_v0.1"

model = ParlerTTSForConditionalGeneration.from_pretrained(repo_id).to("cuda")
tokenizer = AutoTokenizer.from_pretrained(repo_id, padding_side="left")
feature_extractor = AutoFeatureExtractor.from_pretrained(repo_id)

description = "A male speaker with a monotone and high-pitched voice is delivering his speech at a really low speed in a confined environment."
input_text = "Hey, how are you doing?"

inputs = tokenizer([description, description], return_tensors="pt", padding=True).to("cuda")
prompt = tokenizer([input_text, "hey"], return_tensors="pt", padding=True).to("cuda")

set_seed(0)
generation = model.generate(
    input_ids=inputs.input_ids,
    attention_mask=inputs.attention_mask,
    prompt_input_ids=prompt.input_ids,
    prompt_attention_mask=prompt.attention_mask,
    do_sample=True,
    return_dict_in_generate=True,
)

audio_1 = generation.sequences[0, :generation.audios_length[0]]
audio_2 = generation.sequences[1, :generation.audios_length[1]]

print(audio_1.shape, audio_2.shape)
scipy.io.wavfile.write("sample_out.wav", rate=feature_extractor.sampling_rate, data=audio_1.cpu().numpy().squeeze())
scipy.io.wavfile.write("sample_out_2.wav", rate=feature_extractor.sampling_rate, data=audio_2.cpu().numpy().squeeze())
```

In the previous snippet, we'e got : `torch.Size([74752]) torch.Size([45056])`


cc @sanchit-gandhi, do you feel the design makes sense ? I'll add this to a .md in a subsequent PR (with torch compile)
