### PR TITLE
LORA Implementation for Parameter Efficient Fine-Tuning on new datasets

### DIFF
--- a/training/arguments.py
+++ b/training/arguments.py
@@ -366,3 +366,31 @@ class ParlerTTSTrainingArguments(Seq2SeqTrainingArguments):
             "help": "Flag to use parameter efficient fine-tuning, with LORA, for the decoder transformer. Default is without LORA"
         },
     )
+
+    lora_r: int = field(
+    default=8,
+    metadata={
+        "help": (
+            "The rank of the low-rank adaptation matrices in LORA. "
+        )
+    },
+    )
+
+    lora_alpha: float = field(
+    default=16.0,
+    metadata={
+        "help": (
+            "The scaling factor for the LORA updates. Controls strength of the adaptation "
+        )
+    },
+    )
+
+    lora_dropout: float = field(
+    default=0.05,
+    metadata={
+        "help": (
+            "The dropout rate applied to the LORA layers during training. "
+        )
+    },
+    )
+

--- a/training/arguments.py
+++ b/training/arguments.py
@@ -360,3 +360,9 @@ class ParlerTTSTrainingArguments(Seq2SeqTrainingArguments):
             )
         },
     )
+    use_peft: bool = field(
+        default=False,
+        metadata={
+            "help": "Flag to use parameter efficient fine-tuning, with LORA, for the decoder transformer. Default is without LORA"
+        },
+    )

--- a/training/peft_utils.py
+++ b/training/peft_utils.py
@@ -13,8 +13,8 @@ class LoRALinear(nn.Module):
         self.lora_A = nn.Linear(linear_layer.in_features, lora_r, bias=False)
         self.lora_B = nn.Linear(lora_r, linear_layer.out_features, bias=False)
 
-        init.zeros_(self.lora_A.weight)
-        init.zeros_(self.lora_B.weight)
+        nn.init.zeros_(self.lora_A.weight)
+        nn.init.zeros_(self.lora_B.weight)
 
         self.scaling = self.lora_alpha / self.lora_r
         

--- a/training/peft_utils.py
+++ b/training/peft_utils.py
@@ -17,13 +17,12 @@ class LoRALinear(nn.Module):
 
         nn.init.kaiming_uniform_(self.lora_A.weight, a=math.sqrt(5)) # following microsoft/LoRA
         nn.init.zeros_(self.lora_B.weight)
-        #nn.init.zeros_(self.lora_A.weight)
 
         self.scaling = self.lora_alpha / self.lora_r
         self.linear.requires_grad_(False)
 
     def forward(self, x):
-        out = self.linear(x) + self.lora_B(self.lora_A(self.lora_dropout(x))) * self.scaling
+        out = self.linear(x) + torch.relu(self.lora_B(self.lora_A(self.lora_dropout(x))) * self.scaling)
         return out
 
 def replace_linear_with_lora_old(model, lora_r, lora_alpha, lora_dropout):

--- a/training/peft_utils.py
+++ b/training/peft_utils.py
@@ -1,0 +1,39 @@
+import torch.nn as nn
+
+class LoRALinear(nn.Module):
+    def __init__(self, linear_layer, lora_r, lora_alpha, lora_dropout):
+        super().__init__()
+        self.linear = linear_layer
+        self.lora_r = lora_r
+        self.lora_alpha = lora_alpha
+        self.lora_dropout = nn.Dropout(p=lora_dropout)
+        
+        self.lora_A = nn.Linear(linear_layer.in_features, lora_r, bias=False)
+        self.lora_B = nn.Linear(lora_r, linear_layer.out_features, bias=False)
+        self.scaling = self.lora_alpha / self.lora_r
+        
+    def forward(self, x):
+        x = self.lora_dropout(x)
+        x = self.linear(x) + self.lora_B(self.lora_A(x)) * self.scaling
+        return x
+
+def replace_linear_with_lora(model, lora_r, lora_alpha, lora_dropout):
+    for name, module in model.named_modules():
+        if any(item in name for item in ['embed_prompts', 'lm_heads']):
+            print('Ignored adding peft to ', name)
+            continue
+
+        if isinstance(module, nn.Linear):
+            lora_linear = LoRALinear(module, lora_r, lora_alpha, lora_dropout)
+            setattr(model, name, lora_linear)
+    return model
+
+def set_non_lora_gradients_to_false(model):
+    for name, param in model.named_parameters():
+        if "lora_" not in name:
+            param.requires_grad = False
+
+        if 'lm_heads' in name or 'embed_prompts' in name:
+            param.requires_grad = True 
+            print("Using gradients for lm_heads or embed_prompts", name)
+    return model

--- a/training/peft_utils.py
+++ b/training/peft_utils.py
@@ -14,8 +14,9 @@ class LoRALinear(nn.Module):
         self.lora_A = nn.Linear(linear_layer.in_features, lora_r, bias=False)
         self.lora_B = nn.Linear(lora_r, linear_layer.out_features, bias=False)
 
-        nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5)) # following microsoft/LoRA
+        nn.init.kaiming_uniform_(self.lora_A.weight, a=math.sqrt(5)) # following microsoft/LoRA
         nn.init.zeros_(self.lora_B.weight)
+        #nn.init.zeros_(self.lora_A.weight)
 
         self.scaling = self.lora_alpha / self.lora_r
         

--- a/training/peft_utils.py
+++ b/training/peft_utils.py
@@ -7,6 +7,7 @@ class LoRALinear(nn.Module):
     def __init__(self, linear_layer, lora_r, lora_alpha, lora_dropout):
         super().__init__()
         self.linear = linear_layer
+        
         self.lora_r = lora_r
         self.lora_alpha = lora_alpha
         self.lora_dropout = nn.Dropout(p=lora_dropout)
@@ -19,10 +20,10 @@ class LoRALinear(nn.Module):
         #nn.init.zeros_(self.lora_A.weight)
 
         self.scaling = self.lora_alpha / self.lora_r
-        
+        self.linear.requires_grad_(False)
+
     def forward(self, x):
-        out = self.linear(x)
-        out = out + self.lora_B(self.lora_A(self.lora_dropout(x))) * self.scaling
+        out = self.linear(x) + self.lora_B(self.lora_A(self.lora_dropout(x))) * self.scaling
         return out
 
 def replace_linear_with_lora_old(model, lora_r, lora_alpha, lora_dropout):

--- a/training/peft_utils.py
+++ b/training/peft_utils.py
@@ -1,4 +1,6 @@
 import torch.nn as nn
+import torch
+from tqdm import tqdm 
 
 class LoRALinear(nn.Module):
     def __init__(self, linear_layer, lora_r, lora_alpha, lora_dropout):
@@ -10,6 +12,10 @@ class LoRALinear(nn.Module):
         
         self.lora_A = nn.Linear(linear_layer.in_features, lora_r, bias=False)
         self.lora_B = nn.Linear(lora_r, linear_layer.out_features, bias=False)
+
+        init.zeros_(self.lora_A.weight)
+        init.zeros_(self.lora_B.weight)
+
         self.scaling = self.lora_alpha / self.lora_r
         
     def forward(self, x):
@@ -17,7 +23,7 @@ class LoRALinear(nn.Module):
         x = self.linear(x) + self.lora_B(self.lora_A(x)) * self.scaling
         return x
 
-def replace_linear_with_lora(model, lora_r, lora_alpha, lora_dropout):
+def replace_linear_with_lora_old(model, lora_r, lora_alpha, lora_dropout):
     for name, module in model.named_modules():
         if any(item in name for item in ['embed_prompts', 'lm_heads']):
             print('Ignored adding peft to ', name)
@@ -26,6 +32,43 @@ def replace_linear_with_lora(model, lora_r, lora_alpha, lora_dropout):
         if isinstance(module, nn.Linear):
             lora_linear = LoRALinear(module, lora_r, lora_alpha, lora_dropout)
             setattr(model, name, lora_linear)
+    return model
+
+def replace_linear_with_lora(model, lora_r, lora_alpha, lora_dropout):
+    full_name_dict = {module: name for name, module in model.named_modules()}
+    linear_info = {}
+    modules = [model]
+    while len(modules) > 0:
+        submodule = modules.pop()
+        for name, raw_linear in submodule.named_children():
+            if isinstance(raw_linear, torch.nn.Linear):
+                full_name = full_name_dict[raw_linear]
+                linear_info[raw_linear] = {
+                    "father": submodule,
+                    "name": name,
+                    "full_name": full_name,
+                }
+            else:
+                modules.append(raw_linear)
+
+    for total_len, _ in enumerate(model.named_modules()):
+        pass
+
+    i = 0
+    for name, module in tqdm(model.named_modules(), total=total_len, desc='Replacing Linear with Low-Rank Layers', mininterval=5):
+        if any(item in name for item in ['embed_prompts', 'lm_heads']):
+        	print('Ignored adding peft to ', name)
+
+        elif module in linear_info:
+            info = linear_info[module]
+            new_module = LoRALinear(module, lora_r, lora_alpha, lora_dropout)
+            setattr(info["father"], info["name"], new_module)
+
+            del linear_info[module]
+            torch.cuda.empty_cache()
+
+    torch.cuda.empty_cache()
+    print('Replaced linear layers with low-rank layers.')
     return model
 
 def set_non_lora_gradients_to_false(model):

--- a/training/run_parler_tts_training.py
+++ b/training/run_parler_tts_training.py
@@ -64,7 +64,7 @@ from training.utils import (
 from training.arguments import ModelArguments, DataTrainingArguments, ParlerTTSTrainingArguments
 from training.data import load_multiple_datasets, DataCollatorParlerTTSWithPadding, DataCollatorEncodecWithPadding
 from training.eval import clap_similarity, wer, si_sdr
-from training.peft_utils import replace_linear_with_lora, set_non_lora_gradients_to_false
+from training.peft_utils import replace_linear_with_lora, replace_lora_with_linear
 
 logger = logging.getLogger(__name__)
 

--- a/training/run_parler_tts_training.py
+++ b/training/run_parler_tts_training.py
@@ -336,7 +336,7 @@ def main():
     )
 
     if training_args.use_peft == True: 
-        replace_linear_with_lora(model.decoder, lora_r=8, lora_alpha=16, lora_dropout=0.05)
+        replace_linear_with_lora(model.decoder, lora_r=training_args.lora_r, lora_alpha=training_args.lora_alpha, lora_dropout=training_args.lora_dropout)
         set_non_lora_gradients_to_false(model.decoder)
     
     print_trainable_params(model)

--- a/training/run_parler_tts_training.py
+++ b/training/run_parler_tts_training.py
@@ -336,11 +336,9 @@ def main():
     )
 
     if training_args.use_peft == True: 
+        logger.info('\n--Using PEFT, replacing layers--\n')
         replace_linear_with_lora(model.decoder, lora_r=training_args.lora_r, lora_alpha=training_args.lora_alpha, lora_dropout=training_args.lora_dropout)
-        set_non_lora_gradients_to_false(model.decoder)
     
-    print_trainable_params(model)
-
     # enable gradient checkpointing if necessary
     if training_args.gradient_checkpointing:
         model.gradient_checkpointing_enable()
@@ -757,6 +755,8 @@ def main():
 
     # Prepare everything with accelerate
     model, optimizer, lr_scheduler = accelerator.prepare(model, optimizer, lr_scheduler)
+
+    print_trainable_params(model) # print trainable params, for lora
 
     logger.info("***** Running training *****")
     logger.info(f"  Num examples = {total_train_steps * train_batch_size * gradient_accumulation_steps}")

--- a/training/run_parler_tts_training.py
+++ b/training/run_parler_tts_training.py
@@ -64,6 +64,7 @@ from training.utils import (
 from training.arguments import ModelArguments, DataTrainingArguments, ParlerTTSTrainingArguments
 from training.data import load_multiple_datasets, DataCollatorParlerTTSWithPadding, DataCollatorEncodecWithPadding
 from training.eval import clap_similarity, wer, si_sdr
+from training.peft_utils import replace_linear_with_lora, set_non_lora_gradients_to_false
 
 logger = logging.getLogger(__name__)
 
@@ -332,6 +333,11 @@ def main():
         trust_remote_code=data_args.trust_remote_code,
         attn_implementation=model_args.attn_implementation,
     )
+
+    do_peft = True 
+    if do_peft: 
+        replace_linear_with_lora(model.decoder, lora_r=16, lora_alpha=32, lora_dropout=0.05)
+        set_non_lora_gradients_to_false(model.decoder)
 
     # enable gradient checkpointing if necessary
     if training_args.gradient_checkpointing:


### PR DESCRIPTION
Addresses #158 and the request for PEFT mentioned in the README. 

## Feature
This PR adds PEFT support with Low-Rank adapters (LORA) for fine-tuning Parler-TTS on new datasets.

LORA is applied to the Parler-TTS decoder Transformer where PEFT is applied to Linear projection layers. With the T5 encoder of Parler-Mini frozen, PEFT trains only 8% params, compared to 50% without PEFT

## Benefits
* PEFT enables Fine-tuning of Parler-Mini on 8GB GPU (with limited offloading?). 
    * On my windows machine, it takes 29.52s/it with PEFT and 117.50s/it without PEFT for fine-tuning. 
* PEFT enables Fine-Tuning of Parler-TTS Large, 2.3B on Google Collab. Without, I get OOM error. 


## Results:
![image](https://github.com/user-attachments/assets/da4f691b-054d-4853-bf41-2794a0e4fc0c)

* Training plots with PEFT and without PEFT can be found in this Weights and Biases [Report](https://api.wandb.ai/links/sidhant_ls/qh5pnbq2) along with generated audio samples by the two models. This is fine-tuning on Jenny-6H.
* Audio Samples Comparison: Audio samples sounds very similar. In some cases, the PEFT model produces better (better pronunciation and no cut-off at the end): Refer to Index 47, 49

## Reproduce: 
* Google Collab: [Notebook](https://colab.research.google.com/drive/1TOOirwwWhxu3Fu6fPsei3M7-Qj94wZxp?usp=sharing). To turn off PEFT, set USE_PEFT=false

## To do: 
* Analysis to see if Parameter Efficient Fine-Tuning will be useful to the community @ylacombe @sanchit-gandhi 
* Complete PR Code: Saving Model:
    * After PEFT training is complete, it requires the adapters to be removed and saved. I have implemented this, but it is an in-place operation. So, how are we going to save checkpoints? For the final model, we can use this in-place operation with replaces adapters with regular layers so that the model can be loaded the same way without any other code changes 



