### PR TITLE
fix: Update bandwidth parameter check in apply_audio_decoder

### DIFF
--- a/training/run_parler_tts_training.py
+++ b/training/run_parler_tts_training.py
@@ -433,7 +433,7 @@ def main():
         def apply_audio_decoder(batch):
             len_audio = batch.pop("len_audio")
             audio_decoder.to(batch["input_values"].device).eval()
-            if bandwidth is not None:
+            if bandwidth in encoder_signature:
                 batch["bandwidth"] = bandwidth
             elif "num_quantizers" in encoder_signature:
                 batch["num_quantizers"] = num_codebooks


### PR DESCRIPTION
Changes the condition for adding bandwidth parameter from direct access to checking if it exists in encoder_signature.

Before:
if bandwidth is not None:
    batch["bandwidth"] = bandwidth

After:
if bandwidth in encoder_signature:
    batch["bandwidth"] = bandwidth

This fixes the "unexpected keyword argument 'bandwidth'" error by only adding the parameter when it's supported by the encoder signature. I was getting the error while trying to finetune the model