### PR TITLE
replaced max_batch_size with batch_size for StaticCache

### DIFF
--- a/parler_tts/modeling_parler_tts.py
+++ b/parler_tts/modeling_parler_tts.py
@@ -3272,7 +3272,7 @@ class ParlerTTSForConditionalGeneration(PreTrainedModel):
         need_new_cache = (
             not hasattr(self, "_cache")
             or (not isinstance(cache_to_check, cache_cls))
-            or cache_to_check.max_batch_size != max_batch_size
+            or cache_to_check.batch_size != max_batch_size
             or cache_to_check.max_cache_len < max_cache_len
         )
 


### PR DESCRIPTION
The 'max_batch_size' argument of StaticCache is deprecated and sometimes it return error "AttributeError: 'StaticCache' object has no attribute 'max_batch_size'" when calling the ParlerTTSForConditionalGeneration's "generate" method.